### PR TITLE
Kalypso Base for listener-v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ members = [
     "common", 
     "ivs",
     "prover",
+    "prover-executable",
     "bindings"
 ]

--- a/README.md
+++ b/README.md
@@ -1,27 +1,50 @@
 # kalypso-executable-base
 
-The Repo contains template/base code to create `prover-executable` and `input-verification-executable` required by Kalypso
+The Repo contains template/base code to create`prover-gateway`, `prover-executable` and `input-verification-executable` required by Kalypso
 
-## Prover Executable
-Edit code `prover/src/main.rs`
-Build
-```rust
+## 1. Build `prover-gateway`
+Required for provers that do not operate inside enclave
+Edit `prover/main.rs`
+Build *prover-gateway*
+```
 cargo build --release --bin prover
 ```
 
-Copy and Rename `prover` to `prover-executable` (As expected by kalypso's enclave image)
+Copy *prover*
+```
+cp ./target/x86_64-unknown-linux-musl/release/prover prover-gateway
+```
+
+## 2. Build `prover-executable`
+Required for provers that operate inside enclave
+Edit `prover/main.rs`
+Build *prover-gateway*
+```
+cargo build --release --bin prover --features confidential
+```
+Copy *prover*
 ```
 cp ./target/x86_64-unknown-linux-musl/release/prover prover-executable
 ```
 
-## Input Verification Executable
-Edit code `ivs/src/main.rs`
-Build
-```rust
-cargo build --release --bin prover
+## 3. Build `input-verification-executable`
+Required for provers that do not operate proof generation inside enclave. This executable only verifies input and generates attestations for invalid inputs.
+Edit `ivs/main.rs`
+Build *input-verification-service*
+```
+cargo build --release --bin ivs --features confidential
 ```
 
-Copy and Rename `ivs` to `input-verification-executable` (As expected by kalypso's enclave image)
+Copy *ivs*
 ```
 cp ./target/x86_64-unknown-linux-musl/release/ivs input-verification-executable
+```
+
+## 4. Build simplest `prover-executable`
+This is the simplest and most recommnended prover setup. This contains all the end points which makes enclave work as both Prover and IVS
+Edit `ivs/main.rs`
+Edit `prover/main.rs`
+Build *prover-executable*
+```
+cargo build --release --bin prover-executable --features confidential
 ```

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,6 +12,7 @@ aes-gcm = "0.10.3"
 ecies = { version = "0.2.7", features = ["std"] }
 openssl = { version = "0.10.64", features = ["vendored"] }
 ethers = { version = "2.0.14", features = ["abigen", "ws", "rustls"] }
-
-[dev-dependencies]
 hex = "0.4"
+
+[features]
+confidential = []

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -54,20 +54,31 @@ pub fn response(
     response_handler.create_http_response()
 }
 
-use bindings::shared_types::Ask;
-
-#[derive(Serialize, Debug, Deserialize)]
-pub struct GenerateProofInputs {
-    pub ask: Ask,
-    pub private_inputs: Vec<u8>,
-    pub ask_id: u64,
-}
-
 #[derive(Serialize, Debug, Deserialize)]
 pub struct InputPayload {
     pub public: String,
-    pub secrets: Option<String>,
+    #[cfg(feature = "confidential")]
+    pub secrets: String,
 }
+
+#[derive(Serialize, Debug, Deserialize)]
+pub struct CheckInputResponse {
+    pub valid: bool,
+}
+
+#[derive(Serialize, Debug, Deserialize)]
+pub struct GenerateProofResponse {
+    pub proof: String,
+}
+
+#[derive(Serialize)]
+pub struct InvalidInputPayload {
+    pub ask_id: String,
+    pub public: String,
+    #[cfg(feature = "confidential")]
+    pub secrets: String,
+}
+pub mod secret_inputs_helpers;
 
 #[derive(Serialize, Debug, Deserialize)]
 pub struct EncryptedInputPayload {
@@ -75,13 +86,4 @@ pub struct EncryptedInputPayload {
     pub encrypted_secrets: String,
     pub me_decryption_url: String,
     pub market_id: String,
-}
-
-pub mod secret_inputs_helpers;
-
-#[derive(Serialize, Debug, Deserialize)]
-pub struct AskPayload {
-    pub ask_id: u64,
-    pub encrypted_secret: String,
-    pub acl: String,
 }

--- a/ivs/Cargo.toml
+++ b/ivs/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2021"
 [dependencies]
 actix-web = "4.7.0"
 common = { path = "../common" }
+serde_json = "1.0.117"
+
+[features]
+confidential = ["common/confidential"]

--- a/ivs/src/handler.rs
+++ b/ivs/src/handler.rs
@@ -8,10 +8,30 @@ async fn test() -> impl Responder {
 
 #[post("/checkInputs")]
 async fn check_input_handler(_payload: web::Json<common::InputPayload>) -> impl Responder {
+    let check_input_response = common::CheckInputResponse { valid: false };
+
+    let check_input_json = serde_json::to_value(check_input_response).unwrap();
+
     common::response(
         "Check Inputs API is not implemented",
         StatusCode::NOT_IMPLEMENTED,
-        None,
+        Some(check_input_json),
+    )
+}
+
+#[post("/generateProofForInvalidInputs")]
+async fn generate_proof_for_invalid_inputs(
+    _payload: web::Json<common::InputPayload>,
+) -> impl Responder {
+    let proof = common::GenerateProofResponse {
+        proof: "todo".into(),
+    };
+    let proof_json = serde_json::to_value(proof).unwrap();
+
+    common::response(
+        "Generate Proofs for Invalid Inputs is not implement",
+        StatusCode::NOT_IMPLEMENTED,
+        Some(proof_json),
     )
 }
 
@@ -25,30 +45,11 @@ async fn check_enc_handler(_payload: web::Json<common::EncryptedInputPayload>) -
     )
 }
 
-#[post("/checkInputsWithSignature")]
-async fn check_input_with_signature(_payload: web::Json<common::AskPayload>) -> impl Responder {
-    // use common::secret_inputs_helpers to read encryptions and decryptions
-    common::response(
-        "Check Inputs with signature is not implemented",
-        StatusCode::NOT_IMPLEMENTED,
-        None,
-    )
-}
-
-#[post("/verifyInputsAndProof")]
-async fn verify_inputs_and_proof(_payload: web::Json<common::InputPayload>) -> impl Responder {
-    // use common::secret_inputs_helpers to read encryptions and decryptions
-    common::response(
-        "Check Inputs with signature is not implemented",
-        StatusCode::NOT_IMPLEMENTED,
-        None,
-    )
-}
-
 pub fn routes(conf: &mut web::ServiceConfig) {
     let scope = web::scope("/api")
         .service(test)
         .service(check_input_handler)
+        .service(generate_proof_for_invalid_inputs)
         .service(check_enc_handler);
 
     conf.service(scope);

--- a/ivs/src/lib.rs
+++ b/ivs/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod handler;

--- a/prover-executable/Cargo.toml
+++ b/prover-executable/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "prover"
+name = "prover-executable"
 version = "0.1.0"
 edition = "2021"
 
@@ -7,6 +7,9 @@ edition = "2021"
 actix-web = "4.7.0"
 common = { path = "../common" }
 serde_json = "1.0.117"
+prover ={ path ="../prover", features = ["confidential"]}
+ivs ={ path ="../ivs", features = ["confidential"]}
 
 [features]
+default = ["confidential"]
 confidential = ["common/confidential"]

--- a/prover-executable/src/handler.rs
+++ b/prover-executable/src/handler.rs
@@ -1,0 +1,13 @@
+use actix_web::web;
+
+pub fn routes(conf: &mut web::ServiceConfig) {
+    let scope = web::scope("/api")
+        .service(prover::handler::test)
+        .service(prover::handler::benchmark)
+        .service(prover::handler::generate_proof)
+        .service(ivs::handler::check_input_handler)
+        .service(ivs::handler::generate_proof_for_invalid_inputs)
+        .service(ivs::handler::check_enc_handler);
+
+    conf.service(scope);
+}

--- a/prover-executable/src/main.rs
+++ b/prover-executable/src/main.rs
@@ -1,0 +1,17 @@
+mod handler;
+
+use actix_web::{App, HttpServer};
+use std::time::Duration;
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    let port: u16 = 3000;
+
+    let server = HttpServer::new(move || App::new().configure(handler::routes))
+        .client_request_timeout(Duration::new(0, 0))
+        .bind(("0.0.0.0", port))
+        .unwrap_or_else(|_| panic!("Can not bind to {}", &port))
+        .run();
+
+    server.await
+}

--- a/prover/src/handler.rs
+++ b/prover/src/handler.rs
@@ -2,12 +2,12 @@ use actix_web::{get, post};
 use actix_web::{http::StatusCode, web, Responder};
 
 #[get("/test")]
-async fn test() -> impl Responder {
+pub async fn test() -> impl Responder {
     common::response("Generator is running", StatusCode::OK, None)
 }
 
 #[get("/benchmark")]
-async fn benchmark() -> impl Responder {
+pub async fn benchmark() -> impl Responder {
     common::response(
         "Benchmarking API is not implemented",
         StatusCode::NOT_IMPLEMENTED,
@@ -16,11 +16,16 @@ async fn benchmark() -> impl Responder {
 }
 
 #[post("/generateProof")]
-async fn generate_proof(_jsonbody: web::Json<common::GenerateProofInputs>) -> impl Responder {
+pub async fn generate_proof(_jsonbody: web::Json<common::InputPayload>) -> impl Responder {
+    let proof = common::GenerateProofResponse {
+        proof: "todo".into(),
+    };
+    let proof_json = serde_json::to_value(proof).unwrap();
+
     common::response(
         "Proof Generation API is not implemented",
         StatusCode::NOT_IMPLEMENTED,
-        None,
+        Some(proof_json),
     )
 }
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod handler;


### PR DESCRIPTION
Updates the enpoints to match all `kalypso-listener-v2`

All the prover-exeuctables and input-verification executables must be derived from this repo. 